### PR TITLE
Rebuild resume site using React and Vite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+npm-debug.log*
+dist
+.DS_Store
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Test
-Test
+# Eduardo Fernández Ortiz Portfolio
+
+A responsive single-page portfolio for Project Director Eduardo Fernández Ortiz, built with React and Vite.
+
+## Getting Started
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+```bash
+npm run build
+```

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Eduardo Fernández Ortiz | Project Director Portfolio</title>
+    <meta
+      name="description"
+      content="Portfolio site for Eduardo Fernández Ortiz, an accomplished Project Director specializing in large-scale infrastructure delivery across North America and Europe."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@300;400;500;600;700&family=Libre+Franklin:wght@400;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "eduardo-fernandez-ortiz-portfolio",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.0"
+  }
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,25 @@
+import Header from './components/Header.jsx';
+import Hero from './components/Hero.jsx';
+import Expertise from './components/Expertise.jsx';
+import Experience from './components/Experience.jsx';
+import Leadership from './components/Leadership.jsx';
+import Contact from './components/Contact.jsx';
+import Footer from './components/Footer.jsx';
+
+function App() {
+  return (
+    <>
+      <Header />
+      <main id="top">
+        <Hero />
+        <Expertise />
+        <Experience />
+        <Leadership />
+        <Contact />
+      </main>
+      <Footer />
+    </>
+  );
+}
+
+export default App;

--- a/src/components/Contact.jsx
+++ b/src/components/Contact.jsx
@@ -1,0 +1,18 @@
+import { contactContent } from '../data/resumeData.js';
+
+function Contact() {
+  return (
+    <section id="contact" className="section contact">
+      <div className="container">
+        <h2>{contactContent.title}</h2>
+        <p>{contactContent.message}</p>
+        <a className="btn" href={contactContent.button.href}>
+          {contactContent.button.label}
+        </a>
+        <p className="contact__note">{contactContent.note}</p>
+      </div>
+    </section>
+  );
+}
+
+export default Contact;

--- a/src/components/Experience.jsx
+++ b/src/components/Experience.jsx
@@ -1,0 +1,30 @@
+import { experienceContent } from '../data/resumeData.js';
+
+function Experience() {
+  return (
+    <section id="experience" className="section">
+      <div className="container">
+        <h2>Career Highlights</h2>
+        <p className="section__intro">{experienceContent.intro}</p>
+        <div className="timeline" role="list">
+          {experienceContent.roles.map((role) => (
+            <article className="timeline__item" role="listitem" key={role.title}>
+              <span className="timeline__date">{role.dates}</span>
+              <div className="timeline__content">
+                <h3>{role.title}</h3>
+                <p className="timeline__meta">{role.meta}</p>
+                <ul>
+                  {role.bullets.map((bullet) => (
+                    <li key={bullet}>{bullet}</li>
+                  ))}
+                </ul>
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default Experience;

--- a/src/components/Expertise.jsx
+++ b/src/components/Expertise.jsx
@@ -1,0 +1,21 @@
+import { expertiseContent } from '../data/resumeData.js';
+
+function Expertise() {
+  return (
+    <section id="expertise" className="section section--alt">
+      <div className="container">
+        <h2>Core Expertise</h2>
+        <p className="section__intro">{expertiseContent.intro}</p>
+        <div className="pill-grid" role="list">
+          {expertiseContent.items.map((item) => (
+            <span role="listitem" className="pill" key={item}>
+              {item}
+            </span>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default Expertise;

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,11 @@
+function Footer() {
+  return (
+    <footer className="site-footer">
+      <div className="container">
+        <p>&copy; {new Date().getFullYear()} Eduardo Fernández Ortiz. All rights reserved.</p>
+      </div>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { navigationLinks } from '../data/resumeData.js';
+
+function Header() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggleNav = () => setIsOpen((prev) => !prev);
+  const closeNav = () => setIsOpen(false);
+
+  return (
+    <header className="site-header">
+      <div className="container">
+        <a className="logo" href="#top" onClick={closeNav}>
+          EFO
+        </a>
+        <nav className="site-nav" aria-label="Main navigation">
+          <button
+            className={`nav-toggle${isOpen ? ' is-open' : ''}`}
+            aria-expanded={isOpen}
+            aria-controls="primary-navigation"
+            onClick={toggleNav}
+            type="button"
+          >
+            <span className="sr-only">Toggle navigation</span>
+            <span></span>
+            <span></span>
+            <span></span>
+          </button>
+          <ul
+            id="primary-navigation"
+            className={`nav-list${isOpen ? ' is-open' : ''}`}
+          >
+            {navigationLinks.map(({ href, label }) => (
+              <li key={href}>
+                <a href={href} onClick={closeNav}>
+                  {label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+export default Header;

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -1,0 +1,35 @@
+import { heroContent } from '../data/resumeData.js';
+
+function Hero() {
+  return (
+    <section id="about" className="hero">
+      <div className="container hero__grid">
+        <div className="hero__content">
+          <p className="hero__eyebrow">{heroContent.eyebrow}</p>
+          <h1>{heroContent.title}</h1>
+          <p className="hero__lead">{heroContent.lead}</p>
+          <div className="hero__cta">
+            <a className="btn" href={heroContent.primaryCta.href}>
+              {heroContent.primaryCta.label}
+            </a>
+            <a className="btn btn--ghost" href={heroContent.secondaryCta.href}>
+              {heroContent.secondaryCta.label}
+            </a>
+          </div>
+        </div>
+        <div className="hero__details" aria-label="Professional snapshot">
+          <div className="detail-card">
+            <h2>Key Facts</h2>
+            <ul>
+              {heroContent.facts.map((fact) => (
+                <li key={fact}>{fact}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default Hero;

--- a/src/components/Leadership.jsx
+++ b/src/components/Leadership.jsx
@@ -1,0 +1,29 @@
+import { leadershipContent } from '../data/resumeData.js';
+
+function Leadership() {
+  return (
+    <section id="approach" className="section section--alt">
+      <div className="container approach">
+        <div>
+          <h2>{leadershipContent.title}</h2>
+          <p>{leadershipContent.description}</p>
+          <ul className="checklist">
+            {leadershipContent.principles.map((principle) => (
+              <li key={principle}>{principle}</li>
+            ))}
+          </ul>
+        </div>
+        <aside className="approach__aside">
+          <h3>{leadershipContent.outcomesTitle}</h3>
+          <ul>
+            {leadershipContent.outcomes.map((outcome) => (
+              <li key={outcome}>{outcome}</li>
+            ))}
+          </ul>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+export default Leadership;

--- a/src/data/resumeData.js
+++ b/src/data/resumeData.js
@@ -1,0 +1,157 @@
+export const navigationLinks = [
+  { href: '#about', label: 'About' },
+  { href: '#experience', label: 'Experience' },
+  { href: '#expertise', label: 'Expertise' },
+  { href: '#approach', label: 'Leadership' },
+  { href: '#contact', label: 'Contact' }
+];
+
+export const heroContent = {
+  eyebrow: 'Project Director | MSCE, PE, PEng, MBA, PMP',
+  title: 'Eduardo Fernández Ortiz',
+  lead:
+    'Eduardo is a seasoned infrastructure leader with more than two decades of experience guiding multibillion-dollar rail and highway programs across North America and Europe. His strength lies in innovative delivery models—P3, Design-Build, CMAR, and collaborative partnerships—where he aligns cross-functional teams, safeguards commercial performance, and drives sustainable growth.',
+  primaryCta: { href: '#experience', label: 'Explore Experience' },
+  secondaryCta: { href: '#contact', label: 'Connect' },
+  facts: [
+    '20+ years delivering complex infrastructure',
+    '$2.7B Susquehanna River Rail Bridge Commercial Manager',
+    '$600M+ in new business secured (2022-23)',
+    'Multilingual, North America & Europe project expertise'
+  ]
+};
+
+export const expertiseContent = {
+  intro:
+    'Eduardo combines commercial acumen, engineering rigor, and collaborative leadership to deliver landmark transportation programs.',
+  items: [
+    'P3, Design-Build & CMAR Delivery',
+    'Commercial & Contract Management',
+    'Risk & Opportunity Management',
+    'Project Controls & Scheduling',
+    'Stakeholder & Client Engagement',
+    'Proposal Leadership & Capture Planning',
+    'Big Data Analytics for Decision-Making',
+    'Cross-Functional Team Leadership'
+  ]
+};
+
+export const experienceContent = {
+  intro:
+    "A selection of signature programs and leadership roles that showcase Eduardo's ability to orchestrate complex transportation initiatives from pursuit through delivery.",
+  roles: [
+    {
+      dates: '2023 – Present',
+      title: 'Project Commercial Manager — Susquehanna River Rail Bridge',
+      meta: 'Amtrak | CMAR | $2.7B | Washington, D.C.',
+      bullets: [
+        'Leads contract administration, procurement, project controls, communications, DBE participation, and financial management for the bridge replacement.',
+        'Aligns stakeholder goals and regulatory requirements while fostering transparent client relationships.',
+        "Supports delivery of two new high-speed rail structures that unlock capacity and safety across the Northeast Corridor."
+      ]
+    },
+    {
+      dates: '2023 – 2024',
+      title: 'Senior Project Manager — Strategic Pursuits',
+      meta: 'Major U.S. Transportation Programs',
+      bullets: [
+        'Designated Project Chief Engineer and key personnel for the SR-400 Express Lanes P3 pursuit for GDOT.',
+        'Developed capture strategies and proposals for the $2.3B I-10 Calcasieu River Bridge P3 for Louisiana DOTD.',
+        'Facilitated stakeholder workshops to reinforce trust and clarify project expectations.'
+      ]
+    },
+    {
+      dates: '2022 – 2023',
+      title: 'Project Director — Pursuits Portfolio',
+      meta: 'Toronto, Ontario, Canada | Up to $1B Programs',
+      bullets: [
+        'Led cross-functional teams of 50+ professionals on pursuits including EHTH Alliance, Scarborough SE PDB, and Ontario Line EGS PDB.',
+        'Secured over $600M in new business, increasing annual revenue by 14%.',
+        'Embedded rigorous project management practices that boosted efficiency and strengthened client relationships.'
+      ]
+    },
+    {
+      dates: '2017 – 2022',
+      title: 'Technical Manager — Grand Parkway Segments H, I-1 & I-2',
+      meta: 'Texas Department of Transportation | Design-Build | $950M | Houston, TX',
+      bullets: [
+        'Directed the Construction Technical Office, delivering all design packages six months ahead of schedule.',
+        'Managed over 300 design modifications while saving $1M+ in engineering costs.',
+        'Partnered with the JV team to ensure full compliance with TxDOT design-build requirements.'
+      ]
+    },
+    {
+      dates: '2014 – 2017',
+      title: 'Senior Project Manager — I-69 Section 5',
+      meta: 'Indiana Department of Transportation | P3 | $400M | Bloomington, IN',
+      bullets: [
+        'Oversaw scope, budget, schedule, and vendor management across 21 miles of interstate construction.',
+        'Produced executive-level reporting and coordinated risk reviews with construction partners.',
+        'Ensured seamless collaboration between contractor engineering teams and INDOT stakeholders.'
+      ]
+    },
+    {
+      dates: '2010 – 2014',
+      title: 'Technical Director — Major Rail & Highway Programs',
+      meta: 'Bilbao, Spain | €1B Portfolio',
+      bullets: [
+        'Led design and supervision teams across 14 km of tunnels and 5 km of bridges for high-speed rail and highway works.',
+        'Expanded service offerings to include bridge engineering, increasing design output by 20%.',
+        'Mentored 20+ engineers, cultivating high-performing technical teams.'
+      ]
+    },
+    {
+      dates: '2008 – 2010',
+      title: 'Senior Project Manager — High-Speed Rail & Municipal Works',
+      meta: 'Bilbao, Spain | €71M+',
+      bullets: [
+        'Directed design optimization, budgeting, and procurement for the Legutiano–Escoriatza High-Speed Rail project (€60M).',
+        'Oversaw delivery of the Gernika Sewer improvements project (€11M) with strict quality, safety, and environmental compliance.'
+      ]
+    },
+    {
+      dates: '2005 – 2008',
+      title: 'Project Manager — High-Speed Rail Cornellà del Terri to Vilademuls',
+      meta: 'ADIF Alta Velocidad | €80M | Girona, Spain',
+      bullets: [
+        'Managed tunnels and pre-stressed concrete bridges design, procurement, and construction coordination.',
+        'Led multidisciplinary teams to achieve technical excellence across civil, structural, and geotechnical scopes.'
+      ]
+    },
+    {
+      dates: '2003 – 2005',
+      title: 'Construction Supervision Manager — Major Highway Programs',
+      meta: 'San Sebastian, Spain | €146M Combined',
+      bullets: [
+        'Supervised delivery of the 6 km Urumea highway (budget €67M) ensuring adherence to safety and environmental standards.',
+        'Directed oversight for the 8 km AP-1 toll road segment between Eibar and Bergara (€79M).'
+      ]
+    }
+  ]
+};
+
+export const leadershipContent = {
+  title: 'Leadership Approach',
+  description:
+    'Eduardo brings clarity and confidence to complex programs. He aligns technical, commercial, and stakeholder priorities to deliver infrastructure that is on budget, resilient, and future-ready.',
+  principles: [
+    'Champions transparent communication and collaborative delivery models.',
+    'Integrates risk management and data analytics into decision-making.',
+    'Develops high-performing teams with a focus on mentorship and growth.',
+    'Commits to safety, equity, and community impact across every project.'
+  ],
+  outcomesTitle: 'Selected Outcomes',
+  outcomes: [
+    'Accelerated design delivery by six months on a $950M Texas megaproject.',
+    'Captured $600M+ in new business through strategic partnerships.',
+    "Guided commercial excellence for Amtrak's transformative Northeast Corridor investment."
+  ]
+};
+
+export const contactContent = {
+  title: "Let's Build What's Next",
+  message:
+    'Interested in collaborating on resilient infrastructure or exploring leadership opportunities? Connect with Eduardo to discuss how he can elevate your next program.',
+  button: { href: 'mailto:eduardo.fernandez@example.com', label: 'Email Eduardo' },
+  note: 'Prefer a different channel? Connect on LinkedIn or schedule a call.'
+};

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles/main.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,0 +1,456 @@
+:root {
+  --bg: #0d1b2a;
+  --bg-alt: #12263a;
+  --text: #f5f7fa;
+  --text-muted: #c6d4e1;
+  --accent: #00a896;
+  --accent-light: rgba(0, 168, 150, 0.1);
+  --max-width: 1100px;
+  --sans: 'Barlow', 'Helvetica Neue', Arial, sans-serif;
+  --heading: 'Libre Franklin', 'Barlow', 'Helvetica Neue', Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+a {
+  color: inherit;
+}
+
+a:hover,
+a:focus {
+  color: var(--accent);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(100% - 2.5rem, var(--max-width));
+  margin-inline: auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(13, 27, 42, 0.95);
+  backdrop-filter: blur(6px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.site-header .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-block: 1rem;
+}
+
+.logo {
+  font-family: var(--heading);
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border: 2px solid var(--accent);
+  border-radius: 999px;
+}
+
+.site-nav {
+  position: relative;
+}
+
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.nav-toggle span {
+  display: block;
+  width: 1.75rem;
+  height: 2px;
+  background: var(--text);
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.nav-toggle.is-open span:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.nav-toggle.is-open span:nth-child(2) {
+  opacity: 0;
+}
+
+.nav-toggle.is-open span:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+.nav-list {
+  list-style: none;
+  display: flex;
+  gap: 2rem;
+  padding: 0;
+  margin: 0;
+  font-weight: 500;
+}
+
+.nav-list a {
+  text-decoration: none;
+  padding-block: 0.5rem;
+  position: relative;
+}
+
+.nav-list a::after {
+  content: '';
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  height: 2px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.25s ease;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.nav-list a:hover::after,
+.nav-list a:focus::after,
+.nav-list a:focus-visible::after {
+  transform: scaleX(1);
+}
+
+.section {
+  padding-block: clamp(4rem, 6vw, 6rem);
+}
+
+.section--alt {
+  background: var(--bg-alt);
+}
+
+.section h2 {
+  font-family: var(--heading);
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  margin-bottom: 0.5rem;
+}
+
+.section__intro {
+  max-width: 650px;
+  margin-bottom: 2.5rem;
+  color: var(--text-muted);
+}
+
+.hero {
+  padding-block: clamp(5rem, 8vw, 7rem);
+}
+
+.hero__grid {
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+}
+
+.hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.85rem;
+  color: var(--accent);
+  margin: 0 0 1rem;
+}
+
+.hero h1 {
+  font-family: var(--heading);
+  font-size: clamp(2.75rem, 6vw, 4rem);
+  line-height: 1.05;
+  margin: 0 0 1.5rem;
+}
+
+.hero__lead {
+  font-size: 1.1rem;
+  color: var(--text-muted);
+}
+
+.hero__cta {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.hero__details {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.detail-card {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 20px 45px -30px rgba(0, 0, 0, 0.4);
+}
+
+.detail-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: var(--text-muted);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.75rem;
+  border-radius: 999px;
+  background: var(--accent);
+  color: #04111f;
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 20px -12px rgba(0, 168, 150, 0.7);
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--text);
+  border: 2px solid var(--accent);
+}
+
+.pill-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  background: var(--accent-light);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 2.5rem;
+  position: relative;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  inset-inline-start: 0.5rem;
+  top: 0.5rem;
+  bottom: 0.5rem;
+  width: 2px;
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.timeline__item {
+  position: relative;
+  padding-left: 2.5rem;
+}
+
+.timeline__item::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0.7rem;
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 999px;
+  background: var(--accent);
+  box-shadow: 0 0 0 6px rgba(0, 168, 150, 0.15);
+}
+
+.timeline__date {
+  font-weight: 600;
+  color: var(--accent);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.timeline__content h3 {
+  font-family: var(--heading);
+  margin-top: 0.35rem;
+  margin-bottom: 0.35rem;
+}
+
+.timeline__meta {
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  margin-bottom: 0.75rem;
+}
+
+.timeline__content ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--text-muted);
+  display: grid;
+  gap: 0.6rem;
+}
+
+.approach {
+  display: grid;
+  gap: 2.5rem;
+  align-items: start;
+}
+
+.approach__aside {
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 0;
+  color: var(--text-muted);
+  display: grid;
+  gap: 0.85rem;
+}
+
+.checklist li::before {
+  content: '✔';
+  color: var(--accent);
+  margin-right: 0.75rem;
+}
+
+.contact {
+  text-align: center;
+}
+
+.contact p {
+  color: var(--text-muted);
+  max-width: 600px;
+  margin-inline: auto;
+}
+
+.contact__note {
+  font-size: 0.95rem;
+  margin-top: 1rem;
+}
+
+.site-footer {
+  background: #050b12;
+  padding-block: 1.5rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.site-footer span {
+  color: var(--accent);
+}
+
+@media (max-width: 900px) {
+  .hero__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .timeline::before {
+    inset-inline-start: 0.35rem;
+  }
+
+  .timeline__item {
+    padding-left: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-header .container {
+    flex-wrap: wrap;
+  }
+
+  .nav-toggle {
+    display: flex;
+  }
+
+  .nav-list {
+    position: absolute;
+    inset-inline-end: 0;
+    top: 100%;
+    background: rgba(13, 27, 42, 0.98);
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 1.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 0.75rem;
+    gap: 1rem;
+    min-width: 220px;
+    transform: scaleY(0);
+    transform-origin: top;
+    transition: transform 0.2s ease;
+  }
+
+  .nav-list.is-open {
+    transform: scaleY(1);
+  }
+
+  .nav-list a {
+    width: 100%;
+  }
+
+  .hero__cta {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .approach {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './'
+});


### PR DESCRIPTION
## Summary
- rebuild the portfolio as a React single-page application using Vite and modular components for Eduardo Fernández Ortiz
- centralize resume-driven copy in a shared data module powering hero, expertise, experience, leadership, and contact sections
- migrate the existing styling into the React build pipeline with Vite configuration suitable for GitHub Pages deployment

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cf39bda344832190dcd229534df343